### PR TITLE
Feature/version up

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,6 @@ ubuntu
 
 * `node['global']['prefix']` - global install directory
 * `node['global']['version']` - global version to install
-* `node['global']['url']` - URL to global tarball
 
 ## Usage
 

--- a/attributes/default.rb
+++ b/attributes/default.rb
@@ -1,3 +1,2 @@
 default['global']['version'] = '6.2.9'
-default['global']['url'] = "http://tamacom.com/global/global-#{node['global']['version']}.tar.gz"
 default['global']['prefix'] = '/usr/local'

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,7 +1,9 @@
 name             'global'
 maintainer       'Yusuke Murata'
 maintainer_email 'info@muratayusuke.com'
-license          'All rights reserved'
+license           "Apache 2.0"
 description      'Installs/Configures global'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 version          '0.1.1'
+
+supports "ubuntu"

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,5 @@ execute "Extracting and Building Global #{node['global']['version']} from Source
     make
     make install
   COMMAND
-  creates "#{node['global']['prefix']}/bin/global"
   not_if "#{node['global']['prefix']}/bin/global --version | grep #{node['global']['version']}"
 end

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -4,7 +4,7 @@ pkgs.each do |pkg|
 end
 
 remote_file "#{Chef::Config['file_cache_path']}/global-#{node['global']['version']}.tar.gz" do
-  source    node['global']['url']
+  source    "http://tamacom.com/global/global-#{node['global']['version']}.tar.gz"
   mode      00644
   not_if "test -f #{Chef::Config['file_cache_path']}/global-#{node['global']['version']}.tar.gz"
 end


### PR DESCRIPTION
creates "#{node['global']['prefix']}/bin/global"
が在ることで、バージョンアップ時に上書きが上手く行われていなかったので対応しました。

attributesの
default['global']['url'] = "http://tamacom.com/global/global-#{node['global']['version']}.tar.gz"
ですが、この時点では、レシピの['global']['version']を使ってしまい、
ユーザが['global']['version']バージョンのみをセットすると意図しないバージョンのファイルが
別の名前で保存されて、ビルドにこけるという状況になっていたので対応しました。

ライセンスとsupportsを追加しました
